### PR TITLE
Link directly to objects from main campaign listing

### DIFF
--- a/server.py
+++ b/server.py
@@ -329,7 +329,7 @@ def campaigns():
                 for ent in camps:
                     entlist.append(str(ent[0]))
                 campaignents[str(camp[0])] = entlist
-        return render_template('campaigns.html', network=campaigns, campaignents=campaignents)
+        return render_template('campaigns.html', campaignents=campaignents)
     except Exception as e:
         return render_template('error.html', error=e)
 

--- a/server.py
+++ b/server.py
@@ -315,19 +315,19 @@ def campaigns():
                 entlist = []
                 cur = con.cursor()
                 cur.execute(
-                    "SELECT DISTINCT object FROM indicators WHERE length(campaign) < 1")
+                    "SELECT DISTINCT * FROM indicators WHERE length(campaign) < 1")
                 camps = cur.fetchall()
                 for ent in camps:
-                    entlist.append(str(ent[0]))
+                    entlist.append(ent)
                 campaignents["Unknown"] = entlist
             else:
                 entlist = []
                 cur = con.cursor()
                 cur.execute(
-                    "SELECT DISTINCT object FROM indicators WHERE campaign = '" + str(camp[0]) + "'")
+                    "SELECT DISTINCT * FROM indicators WHERE campaign = '" + str(camp[0]) + "'")
                 camps = cur.fetchall()
                 for ent in camps:
-                    entlist.append(str(ent[0]))
+                    entlist.append(ent)
                 campaignents[str(camp[0])] = entlist
         return render_template('campaigns.html', campaignents=campaignents)
     except Exception as e:

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -1,4 +1,4 @@
-{% include "banners/newheader.html" %} 
+{% include "banners/newheader.html" %}
 {% block content %}
 
 <body>
@@ -56,7 +56,7 @@
               <p>Tags</p>
             </a>
           </li>
-            
+
 
         </ul>
       </div>
@@ -135,9 +135,13 @@
                       <th>Indicator</th>
                     </thead>
                     <tbody>
-                      {% for p in campaignents[campaign] %}
+                      {% for ind in campaignents[campaign] %}
                       <tr>
-                        <td><a href="/campaign/{{ p }}/info">{{ p }}</a></td>
+                        {% if ind[2] == "Threat Actor" %}
+                        <td><a href="/threatactors/{{ ind[0] }}/info">{{ ind[1] }}</a></td>
+                        {% else %}
+                        <td><a href="/network/{{ ind[0] }}/info">{{ ind[1] }}</a></td>
+                        {% endif %}
                       </tr>
                       {% endfor %}
                     </tbody>

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -137,10 +137,12 @@
                     <tbody>
                       {% for ind in campaignents[campaign] %}
                       <tr>
-                        {% if ind[2] == "Threat Actor" %}
-                        <td><a href="/threatactors/{{ ind[0] }}/info">{{ ind[1] }}</a></td>
-                        {% else %}
+                        {% if ind[2] == "IPv4" or ind[2] == "IPv6" or ind[2] == "Domain" or ind[2] == "Network"}
                         <td><a href="/network/{{ ind[0] }}/info">{{ ind[1] }}</a></td>
+                        {% elif ind[2] == "Threat Actor" %}
+                        <td><a href="/threatactors/{{ ind[0] }}/info">{{ ind[1] }}</a></td>
+                        {% elif ind[2] == "Hash" %}
+                        <td><a href="/files/{{ ind[0] }}/info">{{ ind[1] }}</a></td>
                         {% endif %}
                       </tr>
                       {% endfor %}


### PR DESCRIPTION
Passes the whole indicator info to the campaigns page and then links correctly based on indicator type. Fixes #61.