### PR TITLE
Git Ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ vagrant/.vagrant/*
 static/uploads/*
 
 *.db
+
+# Common VirtualEnv Path
+# venv

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ static/uploads/*
 *.db
 
 # Common VirtualEnv Path
-# venv
+venv


### PR DESCRIPTION
Most of the time when people are using VirtualEnv they use the path `venv`. Ignoring this path is good practice in Python projects.