### PR TITLE
Set default listener to 127.0.0.1

### DIFF
--- a/server.py
+++ b/server.py
@@ -1116,6 +1116,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--port', help="Specify port to listen on")
     parser.add_argument('-d', '--debug', help="Run in debug mode", action="store_true")
+    parser.add_argument('-H', '--host', default="127.0.0.1", help="Specify the host IP address")
     parser.add_argument('-db', '--database', help="Path to sqlite database - Not Implemented")
     args = parser.parse_args()
 

--- a/server.py
+++ b/server.py
@@ -1125,3 +1125,4 @@ if __name__ == '__main__':
         libs.database.db_file = args.database
 
     init_db()
+    app.run(host=args.host, port=args.port, debug=args.debug)

--- a/server.py
+++ b/server.py
@@ -1102,7 +1102,7 @@ def get_relationships(ip):
                     cur.execute("SELECT * from indicators where object='" + str(rel) + "'")
                     reltype = cur.fetchall()
                     reltype = reltype[0]
-                    temprel[reltype['object']] = reltype['type'] 
+                    temprel[reltype['object']] = reltype['type']
             except:
                 pass
     return jsonify({'relationships': temprel})
@@ -1135,4 +1135,3 @@ if __name__ == '__main__':
         libs.database.db_file = args.database
 
     init_db()
-    app.run(host='0.0.0.0', port=port, debug=debug)

--- a/server.py
+++ b/server.py
@@ -1114,21 +1114,11 @@ def shutdown_session(exception=None):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--port', help="Specify port to listen on")
-    parser.add_argument('-d', '--debug', help="Run in debug mode", action="store_true")
     parser.add_argument('-H', '--host', default="127.0.0.1", help="Specify the host IP address")
+    parser.add_argument('-p', '--port', default=8888, help="Specify port to listen on")
+    parser.add_argument('-d', '--debug', default=False, help="Run in debug mode", action="store_true")
     parser.add_argument('-db', '--database', help="Path to sqlite database - Not Implemented")
     args = parser.parse_args()
-
-    if not args.port:
-        port = 8888
-    else:
-        port = args.port
-
-    if not args.debug:
-        debug = False
-    else:
-        debug = True
 
     if args.database:
         # TODO


### PR DESCRIPTION
I was sitting in a coffeeshop doing some work and realized that my test instance of threat_note was listening on `0.0.0.0`. I randomly checked my subnet IP and saw that threat_note was listening. Given the default information sharing and ease of registering an account this seemed dangerous. 

My first thought was simply that the default listener should be on `localhost` or `127.0.0.1` to "fail closed" but just to make it configurable for others I added a `-H <IPADDRESS>` flag so others can specify their listening IP. Otherwise it defaults closed to `127.0.0.1`. 

While I was at it I also realized that default argparse arguments could shorten the code a bit, so I added those as well.