### PR TITLE
Setup Fix

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn threat_note:app
+web: gunicorn threat_note.server:app

--- a/threat_note/server.py
+++ b/threat_note/server.py
@@ -57,6 +57,9 @@ lm = LoginManager()
 lm.init_app(app)
 lm.login_view = 'login'
 
+# Setup Database if Necessary
+init_db()
+
 app.register_blueprint(tn_api)
 
 
@@ -1004,4 +1007,4 @@ if __name__ == '__main__':
         libs.database.db_file = args.database
 
     init_db()
-    app.run(host=args.host, port=args.port, debug=args.debug)
+    app.run(host=args.host, port=args.port, debug=True)


### PR DESCRIPTION
Turns out in changing the startup to use honcho caused the issue in #100, since `init_db()` is never called. `init_db()` (shockingly) initiates the database, which is pretty important. 

Added it and fixed. It's a bit redundant to have it at the top outside of any method and in the `__name__` method, but at this point it just enables starting with both `python server.py` and `honcho start`. 