### PR TITLE
API & Bidirectional Relationships

### DIFF
--- a/threat_note/libs/API.py
+++ b/threat_note/libs/API.py
@@ -176,10 +176,38 @@ class Relationships(Resource):
     def get(self, arg):
         return {'status': 'not implimented'}
 
-    def post(self, arg):
-        return {'status': 'not implimented'}
+    @apikey
+    def post(self):
 
-# api.add_resource(Relationships, '/api/relationships')
+        try:
+            src = request.form['src']
+            dst = request.form['dst']
+
+            # Add Direct Relationship
+            src_row = Indicator.query.filter_by(object=src).first()
+
+            if src_row.relationships:
+                src_row.relationships = str(src_row.relationships) + ",{}".format(dst)
+            else:
+                src_row.relationships = str(dst)
+
+            db_session.commit()
+
+            # Add Reverse Relationship
+            dst_row = Indicator.query.filter_by(object=dst).first()
+
+            if dst_row.relationships:
+                dst_row.relationships = str(dst_row.relationships) + ",{}".format(src)
+            else:
+                dst_row.relationships = str(src)
+
+            db_session.commit()
+
+            return {'result': 'true', 'source': helpers.row_to_dict(src_row), 'destination': helpers.row_to_dict(dst_row)}, 201
+        except:
+            return {'result': 'false'}, 500
+
+api.add_resource(Relationships, '/api/relationships')
 
 # TODO - Relationships aren't working, so this is untestable
 

--- a/threat_note/libs/API.py
+++ b/threat_note/libs/API.py
@@ -186,10 +186,26 @@ class Relationships(Resource):
 
 class Relationship(Resource):
 
-    def get(self):
-        return {'status': 'not implimented'}
+    @apikey
+    def get(self, target):
 
-# api.add_resource(Relationship, '/api/relationship/<int:id>')
+        indicator = Indicator.query.filter(Indicator.object == target)[0]
+
+        if indicator:
+            try:
+                indicatorlist = []
+                for indicator in indicator.relationships.split(","):
+                    inc = helpers.row_to_dict(Indicator.query.filter(Indicator.object == indicator)[0])
+                    if inc not in indicatorlist:
+                        indicatorlist.append(inc)
+
+                return {target: indicatorlist}
+            except AttributeError:
+                return {target: []}, 404
+        else:
+            return {target: 'Indicator not found.'}, 404
+
+api.add_resource(Relationship, '/api/relationship/<string:target>')
 
 
 class Tags(Resource):

--- a/threat_note/threat_note.py
+++ b/threat_note/threat_note.py
@@ -801,8 +801,24 @@ def addrelationship():
         imd = ImmutableMultiDict(something)
         records = helpers.convert(imd)
 
+        # Add Direct Relationship
         row = Indicator.query.filter_by(object=records['id']).first()
-        row.relationships = records['indicator']
+
+        if row.relationships:
+            row.relationships = str(row.relationships) + ",{}".format(records['indicator'])
+        else:
+            row.relationships = str(records['indicator'])
+
+        db_session.commit()
+
+        # Add Reverse Relationship
+        row = Indicator.query.filter_by(object=records['indicator']).first()
+
+        if row.relationships:
+            row.relationships = str(row.relationships) + ",{}".format(records['id'])
+        else:
+            row.relationships = str(records['id'])
+
         db_session.commit()
 
         if records['type'] == "IPv4" or records['type'] == "IPv6" or records['type'] == "Domain" or \


### PR DESCRIPTION
Relationships used to be one sided (IE the source object would store a reference of all destinations) and that was it. This ended up being problematic as relationships could only be explored from one side, which is problematic, especially from tools like Maltego. As a result I changed it so creating a new relationship it adds the reference to both objects, so they can be found from either direction. 

While I was at it I added API endpoints for both getting a relationship (based on one end point) and creating a relationship (based on providing both endpoints).

I'm sure I'm missing some of the error conditions and things like that, but it's getting started.