### PR TITLE
Updated the PassiveTotal integration to support v2 of the API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Flask-RESTful
 flask-wtf
 honcho
 investigate
+passivetotal

--- a/threat_note/libs/models.py
+++ b/threat_note/libs/models.py
@@ -56,8 +56,12 @@ class Setting(Base):
     circlusername = Column('circlusername', String)
     circlpassword = Column('circlpassword', String)
     circlssl = Column('circlssl', String)
-    ptinfo = Column('ptinfo', String)
-    ptkey = Column('ptkey', String)
+    pt_pdns = Column('pt_pdns', String)
+    pt_whois = Column('pt_whois', String)
+    pt_pssl = Column('pt_pssl', String)
+    pt_host_attr = Column('pt_host_attr', String)
+    pt_username = Column('pt_username', String)
+    pt_api_key = Column('pt_api_key', String)
     cuckoo = Column('cuckoo', String)
     cuckoohost = Column('cuckoohost', String)
     cuckooapiport = Column('cuckooapiport', String)
@@ -66,8 +70,9 @@ class Setting(Base):
     shodaninfo = Column('shodaninfo', String)
     shodankey = Column('shodankey', String)
 
-    def __init__(self, vtinfo, whoisinfo, odnsinfo, circlinfo, farsightinfo, ptinfo, shodaninfo, circlssl, threatcrowd, vtfile,
-                 apikey, odnskey, circlusername, circlpassword, ptkey, farsightkey,
+    def __init__(self, vtinfo, whoisinfo, odnsinfo, circlinfo, farsightinfo, shodaninfo, circlssl, threatcrowd, vtfile,
+                 pt_pdns, pt_whois, pt_pssl, pt_host_attr, pt_username, pt_api_key,
+                 apikey, odnskey, circlusername, circlpassword, farsightkey,
                  cuckoo, cuckoohost, cuckooapiport, httpproxy, httpsproxy, shodankey):
         self.apikey = apikey
         self.odnskey = odnskey
@@ -82,8 +87,12 @@ class Setting(Base):
         self.circlusername = circlusername
         self.circlpassword = circlpassword
         self.circlssl = circlssl
-        self.ptinfo = ptinfo
-        self.ptkey = ptkey
+        self.pt_pdns = pt_pdns
+        self.pt_whois = pt_whois
+        self.pt_pssl = pt_pssl
+        self.pt_host_attr = pt_host_attr
+        self.pt_username = pt_username
+        self.pt_api_key = pt_api_key
         self.cuckoo = cuckoo
         self.cuckoohost = cuckoohost
         self.cuckooapiport = cuckooapiport

--- a/threat_note/libs/passivetotal.py
+++ b/threat_note/libs/passivetotal.py
@@ -22,7 +22,8 @@ def _generate_request_instance(request_type):
     mod = __import__('passivetotal.libs.%s' % request_type,
                      fromlist=[class_name])
     loaded = getattr(mod, class_name)
-    authenticated = loaded(pt_username, pt_api_key)
+    headers = {'PT-INTEGRATION': 'ThreatNote'}
+    authenticated = loaded(pt_username, pt_api_key, headers=headers)
     return authenticated
 
 

--- a/threat_note/libs/passivetotal.py
+++ b/threat_note/libs/passivetotal.py
@@ -1,18 +1,61 @@
-import json
-
-import helpers
-import requests
 from models import Setting
 
 
-def pt(indicator):
+def _generate_request_instance(request_type):
+    """Automatically generate a request instance to use.
+
+    In the end, this saves us from having to load each request class in a
+    explicit way. Loading via a string is helpful to reduce the code per
+    call.
+
+    :param request_type: Type of client to load
+    :return: Loaded PassiveTotal client
+    """
+    settings = Setting.query.filter_by(_id=1).first()
+    pt_username = getattr(settings, 'pt_username', None)
+    pt_api_key = getattr(settings, 'pt_api_key', None)
+
+    class_lookup = {'dns': 'DnsRequest', 'whois': 'WhoisRequest',
+                    'ssl': 'SslRequest', 'enrichment': 'EnrichmentRequest',
+                    'attributes': 'AttributeRequest'}
+    class_name = class_lookup[request_type]
+    mod = __import__('passivetotal.libs.%s' % request_type,
+                     fromlist=[class_name])
+    loaded = getattr(mod, class_name)
+    authenticated = loaded(pt_username, pt_api_key)
+    return authenticated
+
+
+def pt_lookup(query_type, indicator):
     try:
-        settings = Setting.query.filter_by(_id=1).first()
-        apikey = settings.ptkey
-        url = 'https://www.passivetotal.org/api/v1/passive'
-        params = {'api_key': apikey, 'query': indicator}
-        response = requests.get(url, params=params)
-        json_response = json.loads(response.content)
-        return json_response
-    except:
-        pass
+        client = _generate_request_instance(query_type)
+    except Exception as e:
+        return {'error': {
+            'message': 'Failed to load a PassiveTotal client',
+            'developer_message': 'Ensure "passivetotal" has been installed using PIP.'
+        }}
+
+    try:
+        if query_type == 'dns':
+            results = client.get_passive_dns(query=indicator)
+        elif query_type == 'whois':
+            results = client.get_whois_details(query=indicator, compact_record=True)
+            for key, value in results.get('compact', {}).iteritems():
+                data = list()
+                for item in value.get('values', []):
+                    if not item[0]:
+                        continue
+                    string = "%s (%s)" % (item[0], ', '.join(item[1]))
+                    data.append(string)
+                results['compact'][key]['string'] = ', '.join(data)
+        elif query_type == 'ssl':
+            results = client.get_ssl_certificate_history(query=indicator)
+        elif query_type == 'attributes':
+            results = client.get_host_attribute_trackers(query=indicator)
+    except Exception as e:
+        return {'error': {
+            'message': 'Failed to make a PassiveTotal request',
+            'developer_message': 'Ensure network connectivity allows for requests to api.passivetotal.org in order to complete requests!'
+        }}
+
+    return results

--- a/threat_note/templates/networkobject.html
+++ b/threat_note/templates/networkobject.html
@@ -479,35 +479,154 @@
                 </div>
               </div>
             </div>
-            {% endif %} {% endif %} {% if settingsvars['ptinfo'] == "on" %}
+            {% endif %} {% endif %}
+            {% if settingsvars['pt_pdns'] == "on" %}
             <div class="row">
               <div class="col-lg-12">
                 <div class="card">
                   <div class="header">
-                    <h4 class="title">PassiveTotal Passive DNS</h4>
-                    <p class="category">More information can be found at <a href="https://www.passivetotal.org/" target="_blank">PassiveTotal</a></p>
+                    <h4 class="title">PassiveTotal Passive DNS <p class="pull-right" data-toggle="collapse" data-target="#pdns">toggle</p></h4>
+                    <p class="category">PassiveTotal aggregates a number of passive DNS sources from all over the world to create the most comprehensive passive DNS database. Results are filtered to the most recent 1,000 entries, but more data can be found by visiting our <a href="https://www.passivetotal.org/" target="_blank">website</a>.</p>
                   </div>
-                  <div class="content">
+                  <div class="content collapse in" id="pdns">
+                    {% if 'error' in pt_pdns_data %}
+                      <div class="alert alert-danger" role="alert"><strong>{{ pt_pdns_data['error']['message'] }}</strong> {{ pt_pdns_data['error']['developer_message'] }}</div>
+                    {% else %}
                     <table class="table table-hover table-striped">
                       <thead>
                         <th>Resolved</th>
                         <th>First Seen</th>
                         <th>Last Seen</th>
-
+                        <th>Sources</th>
                       </thead>
                       <tbody>
-                        {% for result in ptdata['results']['records'] %}
+                        {% for result in pt_pdns_data.get('results', []) %}
                         <tr>
                           <td>{{ result['resolve'] }}</td>
                           <td>{{ result['firstSeen'] }}</td>
                           <td>{{ result['lastSeen'] }}</td>
+                          <td>{{ ', '.join(result['source']) }}</td>
                         </tr>
                         {% endfor %}
-
-                        <tr>
-
                       </tbody>
                     </table>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+            {% if settingsvars['pt_whois'] == "on" %}
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="card">
+                  <div class="header">
+                    <h4 class="title">PassiveTotal WHOIS <p class="pull-right" data-toggle="collapse" data-target="#whois">toggle</p></h4>
+                    <p class="category">This is the most recent WHOIS record collected by PassiveTotal. In order to run more advanced searches and get additional details, please visit our <a href="https://www.passivetotal.org/" target="_blank">website</a>.</p>
+                  </div>
+                  <div class="content collapse in" id="whois">
+                    {% if 'error' in pt_whois_data %}
+                      <div class="alert alert-danger" role="alert"><strong>{{ pt_whois_data['error']['message'] }}</strong> {{ pt_whois_data['error']['developer_message'] }}</div>
+                    {% else %}
+                    <table class="table table-hover table-striped">
+                      <thead>
+                        <th>Key</th>
+                        <th>Value</th>
+                      </thead>
+                      <tbody>
+                      {% for key in ['contactEmail', 'registrar', 'whoisServer', 'registered', 'registryUpdatedAt', 'expiresAt'] %}
+                        <tr>
+                          <td>{{key}}</td>
+                          <td>{{pt_whois_data.get(key, '')}}</td>
+                        </tr>
+                      {% endfor %}
+                        <tr>
+                          <td>nameServers</td>
+                          <td>{{', '.join(pt_whois_data.get('nameServers', []))}}</td>
+                        </tr>
+                      {% for key, value in pt_whois_data.get('compact', {}).iteritems() %}
+                        <tr>
+                          <td>{{key}}</td>
+                          <td>{{value.get('string', '')}}</td>
+                        </tr>
+                      {% endfor %}
+                      </tbody>
+                    </table>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+            {% if settingsvars['pt_pssl'] == "on" %}
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="card">
+                  <div class="header">
+                    <h4 class="title">PassiveTotal SSL History <p class="pull-right" data-toggle="collapse" data-target="#ssl">toggle</p></h4>
+                    <p class="category">PassiveTotal has collected years of SSL certificates and their associations to IP addresses. Below is the history of SSL certificates associated with an IP address. For more advanced searches, visit our <a href="https://www.passivetotal.org/" target="_blank">website</a>.</p>
+                  </div>
+                  <div class="content collapse in" id="ssl">
+                    {% if 'error' in pt_pssl_data %}
+                      <div class="alert alert-danger" role="alert"><strong>{{ pt_pssl_data['error']['message'] }}</strong> {{ pt_pssl_data['error']['developer_message'] }}</div>
+                    {% else %}
+                    <table class="table table-hover table-striped">
+                      <thead>
+                        <th>SHA-1</th>
+                        <th>First Seen</th>
+                        <th>Last Seen</th>
+                        <th>IP addresses</th>
+                      </thead>
+                      <tbody>
+                      {% for record in pt_pssl_data.get('results', []) %}
+                        <tr>
+                          <td>{{record.get('sha1', 'N/A')}}</td>
+                          <td>{{record.get('firstSeen', 'N/A')}}</td>
+                          <td>{{record.get('lastSeen', 'N/A')}}</td>
+                          <td>{{', '.join(record.get('ipAddresses', []))}}</td>
+                        </tr>
+                      {% endfor %}
+                      </tbody>
+                    </table>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+            {% if settingsvars['pt_host_attr'] == "on" %}
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="card">
+                  <div class="header">
+                    <h4 class="title">PassiveTotal Host Attributes <p class="pull-right" data-toggle="collapse" data-target="#attr">toggle</p></h4>
+                    <p class="category">By leveraging RiskIQ's infrastructure crawling, PassiveTotal has created one of the most comprehensive databases of analytics tracking codes. These include sources like Google, New Relic, Mix Panel and Clicky. For more advanced searches and additional details, visit our <a href="https://www.passivetotal.org/" target="_blank">website</a>.</p>
+                  </div>
+                  <div class="content collapse in" id="attr">
+                    {% if 'error' in pt_host_attr_data %}
+                      <div class="alert alert-danger" role="alert"><strong>{{ pt_host_attr_data['error']['message'] }}</strong> {{ pt_host_attr_data['error']['developer_message'] }}</div>
+                    {% else %}
+                    <table class="table table-hover table-striped">
+                      <thead>
+                        <th>Hostname</th>
+                        <th>First Seen</th>
+                        <th>Last Seen</th>
+                        <th>Type</th>
+                        <th>Value</th>
+                      </thead>
+                      <tbody>
+                      {% for record in pt_host_attr_data.get('results', []) %}
+                        <tr>
+                          <td>{{record.get('hostname', 'N/A')}}</td>
+                          <td>{{record.get('firstSeen', 'N/A')}}</td>
+                          <td>{{record.get('lastSeen', 'N/A')}}</td>
+                          <td>{{record.get('attributeType', 'N/A')}}</td>
+                          <td>{{record.get('attributeValue', 'N/A')}}</td>
+                        </tr>
+                      {% endfor %}
+                      </tbody>
+                    </table>
+                    {% endif %}
                   </div>
                 </div>
               </div>

--- a/threat_note/templates/settings.html
+++ b/threat_note/templates/settings.html
@@ -1,239 +1,272 @@
 {% extends "base.html" %} {% block content %}
 <div class="main-panel">
-  <nav class="navbar navbar-default navbar-fixed">
-    <div class="container-fluid">
-      <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navigation-example-2">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
-        <a class="navbar-brand" href="#">Settings</a>
-      </div>
-      {% include "userdropdown.html" %}
-    </div>
-  </nav>
-  <div class="content">
-    <div class="container-fluid">
-      <div class="row">
-        <div class="col-md-12">
-          <div class="card">
-            <div class="header">
-              <h4 class="title">Settings</h4>
+    <nav class="navbar navbar-default navbar-fixed">
+        <div class="container-fluid">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navigation-example-2">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="#">Settings</a>
             </div>
-            <div class="content">
-              On this page you can turn on any available 3rd party integrations as well as add your API keys for applicable services. You can also configure proxy settings if you need proxy support to reach certain integrations.</p>
-            </div>
-          </div>
+            {% include "userdropdown.html" %}
         </div>
-      </div>
-      <div class="col-md-6">
-        <div class="card ">
-          <form class="form-horizontal" action="/update/settings/" enctype="application/x-www-form-urlencoded" method="POST">
-            <div class="header">
-              <h4 class="title">Proxy Settings</h4>
-              <p class="category">Network Proxy Configuration Settings</p>
-            </div>
-            <div class="content">
-              <div class="row">
-                <div class="col-md-8">
-                  <fieldset>
-                    <label>HTTP</label>
-                    <input type="text" class="form-control" name="httpproxy" value="{{ records['httpproxy'] }}" placeholder="http://127.0.0.1:8080">
-                    </br>
-                    <label>HTTPS</label>
-                    <input type="text" class="form-control" name="httpsproxy" value="{{ records['httpsproxy'] }}" placeholder="https://127.0.0.1:8080">
-                    </br>
-                  </fieldset>
+    </nav>
+    <div class="content">
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="card">
+                        <div class="header">
+                            <h4 class="title">Settings</h4>
+                        </div>
+                        <div class="content">
+                            On this page you can turn on any available 3rd party integrations as well as add your API keys for applicable services. You can also configure proxy settings if you need proxy support to reach certain integrations.</p>
+                        </div>
+                    </div>
                 </div>
-              </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card ">
+                    <form class="form-horizontal" action="/update/settings/" enctype="application/x-www-form-urlencoded" method="POST">
+                        <div class="header">
+                            <h4 class="title">Proxy Settings</h4>
+                            <p class="category">Network Proxy Configuration Settings</p>
+                        </div>
+                        <div class="content">
+                            <div class="row">
+                                <div class="col-md-8">
+                                    <fieldset>
+                                        <label>HTTP</label>
+                                        <input type="text" class="form-control" name="httpproxy" value="{{ records['httpproxy'] }}" placeholder="http://127.0.0.1:8080">
+                                        </br>
+                                        <label>HTTPS</label>
+                                        <input type="text" class="form-control" name="httpsproxy" value="{{ records['httpsproxy'] }}" placeholder="https://127.0.0.1:8080">
+                                        </br>
+                                    </fieldset>
+                                </div>
+                            </div>
+                        </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card ">
+                    <div class="header">
+                        <h4 class="title">3rd Party Integrations</h4>
+                        <p class="category">Configure 3rd Party Data Providers Options</p>
+                    </div>
+                    <div class="header">
+                        <p class="category">Network</p>
+                    </div>
+                    <div class="content table-responsive table-full-width">
+                        <fieldset>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            {% if records['whoisinfo'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="whoisinfo" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="whoisinfo" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>Whois Information</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['farsightinfo'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="farsightinfo" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="farsightinfo" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>Farsight Passive DNS</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['vtinfo'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="vtinfo" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="vtinfo" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>VirusTotal Passive DNS</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['pt_pdns'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="pt_pdns" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="pt_pdns" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>PassiveTotal Passive DNS</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['pt_whois'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="pt_whois" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="pt_whois" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>PassiveTotal WHOIS</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['pt_pssl'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="pt_pssl" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="pt_pssl" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>PassiveTotal Passive SSL</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['pt_host_attr'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="pt_host_attr" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="pt_host_attr" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>PassiveTotal Host Attributes</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['odnsinfo'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="odnsinfo" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="odnsinfo" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>OpenDNS Investigate</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['circlinfo'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="circlinfo" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="circlinfo" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>CIRCL Passive DNS</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['circlssl'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="circlssl" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="circlssl" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>CIRCL Passive SSL</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['shodaninfo'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="shodaninfo" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="shodaninfo" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>Shodan Data</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                    </div>
+                    <div class="header">
+                        <p class="category">File</p>
+                    </div>
+                    <div class="content table-responsive table-full-width">
+                        <fieldset>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            {% if records['vtfile'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="vtfile" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="vtfile" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>VirusTotal File Information</td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            {% if records['cuckoo'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="cuckoo" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="cuckoo" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>Cuckoo Sandbox</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                    </div>
+                    <div class="header">
+                        <p class="category">Visualization</p>
+                    </div>
+                    <div class="content table-responsive table-full-width">
+                        <fieldset>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            {% if records['threatcrowd'] == "on" %}
+                                            <label class="checkbox">
+                                                <input type="checkbox" class="form-control" name="threatcrowd" checked data-toggle="checkbox"> {% else %}
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="form-control" name="threatcrowd" data-toggle="checkbox"> {% endif %}
+                                        </td>
+                                        <td>ThreatCrowd Visualizations</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                    </div>
+                    <div class="content">
+                        <h4 class="title">Configure 3rd Party Integrations</h4>
+                        <label>VirusTotal API Key</label>
+                        <input type="text" class="form-control" name="apikey" value="{{ records['apikey'] }}" placeholder="149d08c494b4db323420180b09312b2f34e529230496cddfa868c01eea">
+                        </br>
+                        <label>OpenDNS Investigate API Key</label>
+                        <input type="text" class="form-control" name="odnskey" value="{{ records['odnskey'] }}" placeholder="89ba67a0-b1f2-75ef-9fb9-04eae0434963">
+                        </br>
+                        <label>CIRCL Username</label>
+                        <input type="text" class="form-control" name="circlusername" value="{{ records['circlusername'] }}" placeholder="Username">
+                        </br>
+                        <label>CIRCL Password</label>
+                        <input type="password" class="form-control" name="circlpassword" value="{{ records['circlpassword'] }}" placeholder="********">
+                        </br>
+                        <label>PassiveTotal Username</label>
+                        <input type="text" class="form-control" name="pt_username" value="{{ records['pt_username'] }}" placeholder="username@domain.com">
+                        </br>
+                        <label>PassiveTotal API Key</label>
+                        <input type="text" class="form-control" name="pt_api_key" value="{{ records['pt_api_key'] }}" placeholder="149d08c494b4db323420180b09312b2f34e529230496cddfa868c01eea">
+                        </br>
+                        <label> Cuckoo Host</label>
+                        <input type="text" class="form-control" name="cuckoohost" value="{{ records['cuckoohost'] }}" placeholder="127.0.0.1">
+                        </br>
+                        <label>Cuckoo API Port</label>
+                        <input type="text" class="form-control" name="cuckooapiport" value="{{ records['cuckooapiport'] }}" placeholder="8090">
+                        </br>
+                        <label>Farsight API Key</label>
+                        <input type="text" class="form-control" name="farsightkey" value="{{ records['farsightkey'] }}" placeholder="149d08c494b4db323420180b09312b2f34e529230496cddfa868c01eea">
+                        </br>
+                        <label>Shodan API Key</label>
+                        <input type="text" class="form-control" name="shodankey" value="{{ records['shodankey'] }}" placeholder=" mO22M3Tyke2341rxMmQAyFKTm0HfjZul">
+                        </br>
+                        <button type="submit" class="btn btn-info btn-fill">Submit</button>
+                    </div>
+                    </fieldset>
+                </div>
             </div>
         </div>
-      </div>
-      <div class="col-md-6">
-        <div class="card ">
-          <div class="header">
-            <h4 class="title">3rd Party Integrations</h4>
-            <p class="category">Configure 3rd Party Data Providers Options</p>
-          </div>
-          <div class="header">
-            <p class="category">Network</p>
-          </div>
-          <div class="content table-responsive table-full-width">
-            <fieldset>
-              <table class="table">
-                <tbody>
-                  <tr>
-                    <td>
-                      {% if records['whoisinfo'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="whoisinfo" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="whoisinfo" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>Whois Information</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      {% if records['farsightinfo'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="farsightinfo" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="farsightinfo" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>Farsight Passive DNS</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      {% if records['vtinfo'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="vtinfo" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="vtinfo" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>VirusTotal Passive DNS</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      {% if records['ptinfo'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="ptinfo" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="ptinfo" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>PassiveTotal Passive DNS</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      {% if records['odnsinfo'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="odnsinfo" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="odnsinfo" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>OpenDNS Investigate</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      {% if records['circlinfo'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="circlinfo" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="circlinfo" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>CIRCL Passive DNS</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      {% if records['circlssl'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="circlssl" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="circlssl" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>CIRCL Passive SSL</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      {% if records['shodaninfo'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="shodaninfo" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="shodaninfo" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>Shodan Data</td>
-                  </tr>
-                </tbody>
-              </table>
-          </div>
-          <div class="header">
-            <p class="category">File</p>
-          </div>
-          <div class="content table-responsive table-full-width">
-            <fieldset>
-              <table class="table">
-                <tbody>
-                  <tr>
-                    <td>
-                      {% if records['vtfile'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="vtfile" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="vtfile" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>VirusTotal File Information</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      {% if records['cuckoo'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="cuckoo" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="cuckoo" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>Cuckoo Sandbox</td>
-                  </tr>
-                </tbody>
-              </table>
-          </div>
-          <div class="header">
-            <p class="category">Visualization</p>
-          </div>
-          <div class="content table-responsive table-full-width">
-            <fieldset>
-              <table class="table">
-                <tbody>
-                  <tr>
-                    <td>
-                      {% if records['threatcrowd'] == "on" %}
-                      <label class="checkbox">
-                        <input type="checkbox" class="form-control" name="threatcrowd" checked data-toggle="checkbox"> {% else %}
-                        <label class="checkbox">
-                          <input type="checkbox" class="form-control" name="threatcrowd" data-toggle="checkbox"> {% endif %}
-                    </td>
-                    <td>ThreatCrowd Visualizations</td>
-                  </tr>
-                </tbody>
-              </table>
-          </div>
-          <div class="content">
-            <h4 class="title">Configure 3rd Party Integrations</h4>
-            <label>VirusTotal API Key</label>
-            <input type="text" class="form-control" name="apikey" value="{{ records['apikey'] }}" placeholder="149d08c494b4db323420180b09312b2f34e529230496cddfa868c01eea">
-            </br>
-            <label>OpenDNS Investigate API Key</label>
-            <input type="text" class="form-control" name="odnskey" value="{{ records['odnskey'] }}" placeholder="89ba67a0-b1f2-75ef-9fb9-04eae0434963">
-            </br>
-            <label>CIRCL Username</label>
-            <input type="text" class="form-control" name="circlusername" value="{{ records['circlusername'] }}" placeholder="Username">
-            </br>
-            <label>CIRCL Password</label>
-            <input type="password" class="form-control" name="circlpassword" value="{{ records['circlpassword'] }}" placeholder="********">
-            </br>
-            <label>PassiveTotal API Key</label>
-            <input type="text" class="form-control" name="ptkey" value="{{ records['ptkey'] }}" placeholder="149d08c494b4db323420180b09312b2f34e529230496cddfa868c01eea">
-            </br>
-            <label> Cuckoo Host</label>
-            <input type="text" class="form-control" name="cuckoohost" value="{{ records['cuckoohost'] }}" placeholder="127.0.0.1">
-            </br>
-            <label>Cuckoo API Port</label>
-            <input type="text" class="form-control" name="cuckooapiport" value="{{ records['cuckooapiport'] }}" placeholder="8090">
-            </br>
-            <label>Farsight API Key</label>
-            <input type="text" class="form-control" name="farsightkey" value="{{ records['farsightkey'] }}" placeholder="149d08c494b4db323420180b09312b2f34e529230496cddfa868c01eea">
-            </br>
-            <label>Shodan API Key</label>
-            <input type="text" class="form-control" name="shodankey" value="{{ records['shodankey'] }}" placeholder=" mO22M3Tyke2341rxMmQAyFKTm0HfjZul">
-            </br>
-            <button type="submit" class="btn btn-info btn-fill">Submit</button>
-          </div>
-          </fieldset>
-        </div>
-      </div>
     </div>
-  </div>
-  {% include "footer.html" %}
+    {% include "footer.html" %}
 </div>
 </div>
 {% endblock content %}

--- a/threat_note/templates/victimobject.html
+++ b/threat_note/templates/victimobject.html
@@ -454,40 +454,158 @@
                     </div>
                     </div>
                     {% endif %}
-{% if settingsvars['ptinfo'] == "on" %}
-                <div class="row">
-                  <div class="col-lg-12">
-                    <div class="card">
-                      <div class="header">
-                        <h4 class="title">PassiveTotal Passive DNS</h4>
-                        <p class="category">More information can be found at <a href="https://www.passivetotal.org/" target="_blank">PassiveTotal</a></p>
-                      </div>
-                      <div class="content">
-                       <table class="table table-hover table-striped">
+            {% if settingsvars['pt_pdns'] == "on" %}
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="card">
+                  <div class="header">
+                    <h4 class="title">PassiveTotal Passive DNS <p class="pull-right" data-toggle="collapse" data-target="#pdns">toggle</p></h4>
+                    <p class="category">PassiveTotal aggregates a number of passive DNS sources from all over the world to create the most comprehensive passive DNS database. Results are filtered to the most recent 1,000 entries, but more data can be found by visiting our <a href="https://www.passivetotal.org/" target="_blank">website</a>.</p>
+                  </div>
+                  <div class="content collapse in" id="pdns">
+                    {% if 'error' in pt_pdns_data %}
+                      <div class="alert alert-danger" role="alert"><strong>{{ pt_pdns_data['error']['message'] }}</strong> {{ pt_pdns_data['error']['developer_message'] }}</div>
+                    {% else %}
+                    <table class="table table-hover table-striped">
                       <thead>
                         <th>Resolved</th>
                         <th>First Seen</th>
                         <th>Last Seen</th>
-
+                        <th>Sources</th>
                       </thead>
                       <tbody>
-                      {% for result in ptdata['results']['records'] %}
-                      <tr>
-                      <td>{{ result['resolve'] }}</td>
-                      <td>{{ result['firstSeen'] }}</td>
-                      <td>{{ result['lastSeen'] }}</td>
-                      </tr>
-                      {% endfor %}
-
-                            <tr>
-
-                            </tbody>
-                            </table>
-                      </div>
-                    </div>
-                    </div>
-                    </div>
+                        {% for result in pt_pdns_data.get('results', []) %}
+                        <tr>
+                          <td>{{ result['resolve'] }}</td>
+                          <td>{{ result['firstSeen'] }}</td>
+                          <td>{{ result['lastSeen'] }}</td>
+                          <td>{{ ', '.join(result['source']) }}</td>
+                        </tr>
+                        {% endfor %}
+                      </tbody>
+                    </table>
                     {% endif %}
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+            {% if settingsvars['pt_whois'] == "on" %}
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="card">
+                  <div class="header">
+                    <h4 class="title">PassiveTotal WHOIS <p class="pull-right" data-toggle="collapse" data-target="#whois">toggle</p></h4>
+                    <p class="category">This is the most recent WHOIS record collected by PassiveTotal. In order to run more advanced searches and get additional details, please visit our <a href="https://www.passivetotal.org/" target="_blank">website</a>.</p>
+                  </div>
+                  <div class="content collapse in" id="whois">
+                    {% if 'error' in pt_whois_data %}
+                      <div class="alert alert-danger" role="alert"><strong>{{ pt_whois_data['error']['message'] }}</strong> {{ pt_whois_data['error']['developer_message'] }}</div>
+                    {% else %}
+                    <table class="table table-hover table-striped">
+                      <thead>
+                        <th>Key</th>
+                        <th>Value</th>
+                      </thead>
+                      <tbody>
+                      {% for key in ['contactEmail', 'registrar', 'whoisServer', 'registered', 'registryUpdatedAt', 'expiresAt'] %}
+                        <tr>
+                          <td>{{key}}</td>
+                          <td>{{pt_whois_data.get(key, '')}}</td>
+                        </tr>
+                      {% endfor %}
+                        <tr>
+                          <td>nameServers</td>
+                          <td>{{', '.join(pt_whois_data.get('nameServers', []))}}</td>
+                        </tr>
+                      {% for key, value in pt_whois_data.get('compact', {}).iteritems() %}
+                        <tr>
+                          <td>{{key}}</td>
+                          <td>{{value.get('string', '')}}</td>
+                        </tr>
+                      {% endfor %}
+                      </tbody>
+                    </table>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+            {% if settingsvars['pt_pssl'] == "on" %}
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="card">
+                  <div class="header">
+                    <h4 class="title">PassiveTotal SSL History <p class="pull-right" data-toggle="collapse" data-target="#ssl">toggle</p></h4>
+                    <p class="category">PassiveTotal has collected years of SSL certificates and their associations to IP addresses. Below is the history of SSL certificates associated with an IP address. For more advanced searches, visit our <a href="https://www.passivetotal.org/" target="_blank">website</a>.</p>
+                  </div>
+                  <div class="content collapse in" id="ssl">
+                    {% if 'error' in pt_pssl_data %}
+                      <div class="alert alert-danger" role="alert"><strong>{{ pt_pssl_data['error']['message'] }}</strong> {{ pt_pssl_data['error']['developer_message'] }}</div>
+                    {% else %}
+                    <table class="table table-hover table-striped">
+                      <thead>
+                        <th>SHA-1</th>
+                        <th>First Seen</th>
+                        <th>Last Seen</th>
+                        <th>IP addresses</th>
+                      </thead>
+                      <tbody>
+                      {% for record in pt_pssl_data.get('results', []) %}
+                        <tr>
+                          <td>{{record.get('sha1', 'N/A')}}</td>
+                          <td>{{record.get('firstSeen', 'N/A')}}</td>
+                          <td>{{record.get('lastSeen', 'N/A')}}</td>
+                          <td>{{', '.join(record.get('ipAddresses', []))}}</td>
+                        </tr>
+                      {% endfor %}
+                      </tbody>
+                    </table>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+            {% if settingsvars['pt_host_attr'] == "on" %}
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="card">
+                  <div class="header">
+                    <h4 class="title">PassiveTotal Host Attributes <p class="pull-right" data-toggle="collapse" data-target="#attr">toggle</p></h4>
+                    <p class="category">By leveraging RiskIQ's infrastructure crawling, PassiveTotal has created one of the most comprehensive databases of analytics tracking codes. These include sources like Google, New Relic, Mix Panel and Clicky. For more advanced searches and additional details, visit our <a href="https://www.passivetotal.org/" target="_blank">website</a>.</p>
+                  </div>
+                  <div class="content collapse in" id="attr">
+                    {% if 'error' in pt_host_attr_data %}
+                      <div class="alert alert-danger" role="alert"><strong>{{ pt_host_attr_data['error']['message'] }}</strong> {{ pt_host_attr_data['error']['developer_message'] }}</div>
+                    {% else %}
+                    <table class="table table-hover table-striped">
+                      <thead>
+                        <th>Hostname</th>
+                        <th>First Seen</th>
+                        <th>Last Seen</th>
+                        <th>Type</th>
+                        <th>Value</th>
+                      </thead>
+                      <tbody>
+                      {% for record in pt_host_attr_data.get('results', []) %}
+                        <tr>
+                          <td>{{record.get('hostname', 'N/A')}}</td>
+                          <td>{{record.get('firstSeen', 'N/A')}}</td>
+                          <td>{{record.get('lastSeen', 'N/A')}}</td>
+                          <td>{{record.get('attributeType', 'N/A')}}</td>
+                          <td>{{record.get('attributeValue', 'N/A')}}</td>
+                        </tr>
+                      {% endfor %}
+                      </tbody>
+                    </table>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% endif %}
 
                               {% if settingsvars['farsightinfo'] == "on" %}
                     {% if records['type'] == "IPv4" %}


### PR DESCRIPTION
This update includes a lot of core changes to anything related to PassiveTotal. Here's what has specifically changed:

- Requirements file now includes 'passivetotal' as a requirement
- PassiveTotal was updated to support both username and API key for authentication
- PassiveTotal datasets were split into their own modules
- PassiveTotal datasets can be hidden from view
- Errors like quota limits, invalid authentication and processing errors are accounted for in a clean way